### PR TITLE
feat: allows triggering workflow also by name

### DIFF
--- a/src/content/services/shortcutListener.js
+++ b/src/content/services/shortcutListener.js
@@ -10,9 +10,9 @@ function automaCustomEventListener(findWorkflow) {
   window.addEventListener(
     'automa:execute-workflow',
     ({ detail }) => {
-      if (!detail || !detail.id) return;
+      if (!detail || (!detail.id && !detail.name)) return;
 
-      const workflow = findWorkflow(detail.id);
+      const workflow = findWorkflow(detail.id, detail.name);
 
       if (!workflow) return;
 
@@ -64,12 +64,14 @@ export default async function () {
         'workflows',
         'workflowHosts',
       ]);
-    const findWorkflow = (id) => {
-      let workflow = workflows.find((item) => item.id === id);
+    const findWorkflow = (id, workflowName) => {
+      let workflow = workflows.find((item) =>
+        id ? item.id === id : item.name === workflowName
+      );
 
       if (!workflow) {
-        workflow = Object.values(workflowHosts || {}).find(
-          ({ hostId }) => hostId === id
+        workflow = Object.values(workflowHosts || {}).find((hostWorkflow) =>
+          id ? hostWorkflow.id === id : hostWorkflow.name === workflowName
         );
 
         if (workflow) workflow.id = workflow.hostId;


### PR DESCRIPTION
Hey @Kholid060,

thank you for implementing the workflow triggering via custom event. I've used it so far and wanted to introduce a colleague for that script only to see that the workflow id is different once you import a workflow. Which is fine (since it could collide with a previous import).

So I decided to upgrade that functionality with identifying workflows via their name. This has the downside that the name isn't unique and could potentially not work correctly, especially when you have workflows with the same name. However I deem that as an acceptable trade-off, but I'm curious what you think.

Best Regards,
TJ