### PR TITLE
enhancement: exclude aria-disabled to find selector when record workflow

### DIFF
--- a/src/content/services/recordWorkflow/recordEvents.js
+++ b/src/content/services/recordWorkflow/recordEvents.js
@@ -16,7 +16,9 @@ const textFieldEl = (el) =>
 function findSelector(element) {
   return finder(element, {
     tagName: () => true,
-    attr: (name, value) => name === 'id' || (name.startsWith('aria') && value),
+    attr: (name, value) =>
+      name === 'id' ||
+      (name.startsWith('aria') && !name.startsWith('aria-disabled') && value),
   });
 }
 async function addBlock(detail) {


### PR DESCRIPTION
Changes:
 - Exclude the `aria-disabled` attribute to get selector when recording workflow.

Why:
 - It's not important for a selector that identified by `aria-disabled` attr
 - It's used for flagging the element whether it's disabled (https://developer.mozilla.org/en-US/docs/Web/Accessibility/ARIA/Attributes/aria-disabled)