### PR TITLE
enhancement: element selector

### DIFF
--- a/src/content/elementSelector/generateElementsSelector.js
+++ b/src/content/elementSelector/generateElementsSelector.js
@@ -47,11 +47,9 @@ export default function ({
       });
     }
   } else {
-    const tagName = selectedElement.tagName.toLowerCase();
-    const candidate = findSelector(selectedElement, finderOptions);
     selector =
       selectorType === 'css'
-        ? `${candidate.startsWith(tagName) ? '' : tagName}${candidate}`
+        ? findSelector(selectedElement, finderOptions)
         : generateXPath(selectedElement);
   }
 

--- a/src/lib/findSelector.js
+++ b/src/lib/findSelector.js
@@ -1,6 +1,7 @@
 import { finder as finderLib } from '@medv/finder';
 
-const ariaAttrs = ['aria-label', 'aria-labelledby'];
+// const ariaAttrs = ['aria-label', 'aria-labelledby'];
+const ariaAttrs = ['data-testid'];
 
 export const finder = finderLib;
 


### PR DESCRIPTION
- delete the tagname in the element selector form, it's usually mismatched with the selected element
- update  to `data-testid` instead of using aria-label to get the high priority attr (https://www.educative.io/answers/what-is-the-data-testid-attribute-in-testing)