### PR TITLE
Fix failure to create multi-level directories, e.g. (build-zip/version)

### DIFF
--- a/utils/build-zip.js
+++ b/utils/build-zip.js
@@ -12,7 +12,7 @@ const destDir = path.join(__dirname, '../build');
 const zipDir = path.join(__dirname, '../build-zip', appVersion);
 
 if (!fs.existsSync(zipDir)) {
-  fs.mkdirSync(zipDir);
+  fs.mkdirSync(zipDir, { recursive: true });
 }
 
 const archive = archiver('zip', { zlib: { level: 9 } });


### PR DESCRIPTION
```
$ node utils/build-zip.js
node:internal/fs/utils:345
    throw err;
    ^
Error: ENOENT: no such file or directory, mkdir 'E:\webProject\automa\build-zip\1.24.3'
 {
  errno: -4058,
  syscall: 'mkdir',
  code: 'ENOENT',
}
```