### PR TITLE
fix: Fix Sizzle incorrect context in iframe, passed as context of iframe

### DIFF
--- a/src/utils/FindElement.js
+++ b/src/utils/FindElement.js
@@ -25,7 +25,8 @@ class FindElement {
       : data.selector;
 
     if (specialSelectorsRegex.test(selector)) {
-      const elements = Sizzle.matches(selector);
+      // Fix Sizzle incorrect context in iframe, passed as context of iframe
+      const elements = Sizzle(selector, documentCtx);
       if (!elements) return null;
 
       return data.multiple ? elements : elements[0];


### PR DESCRIPTION
Fix Sizzle's incorrect context in iframe