### PR TITLE
fix: Trigger input-event before keyup-event to prevent inputmask from resetting element.value

### DIFF
--- a/src/utils/handleFormElement.js
+++ b/src/utils/handleFormElement.js
@@ -23,6 +23,13 @@ function formEvent(element, data) {
       code: `Key${currentKey}`,
     };
 
+    simulateEvent(element, 'input', {
+      inputType: 'insertText',
+      data: data.value,
+      bubbles: true,
+      cancelable: true,
+    });
+
     simulateEvent(element, 'keydown', {
       key,
       code,


### PR DESCRIPTION
On sites that use jQuery and inputmask, inputmask will format the text and reset element.value when the keyup-event is triggered, but the value is not based on the latest element.value but on the old value stored by inputmask, so element. value will not change, and the input-event needs to be triggered in advance to notify inputmask
