### PR TITLE
feat: In  `debugMode` , the  `EventClick`  still cannot bypass the bot detection.

### DIFF
--- a/src/content/blocksHandler/handlerEventClick.js
+++ b/src/content/blocksHandler/handlerEventClick.js
@@ -1,4 +1,5 @@
 import { sendMessage } from '@/utils/message';
+import { sleep } from '@/utils/helper';
 import { getElementPosition, simulateClickElement } from '../utils';
 import handleSelector from '../handleSelector';
 
@@ -27,7 +28,11 @@ function eventClick(block) {
             return sendMessage('debugger:send-command', payload, 'background');
           };
 
+          // bypass the bot detection.
+          await executeCommand('mouseMoved');
+          await sleep(100);
           await executeCommand('mousePressed');
+          await sleep(100);
           await executeCommand('mouseReleased');
 
           return;


### PR DESCRIPTION
When my workflow encounters bot detection, I tried using  `debugMode`  to simulate the click event (as I had no issues with simulating clicks in Playwright). However, executing only  `mousePressed`  and  `mouseReleased`  did not solve the problem, as most bot detections are related to mouse movement. So, I added the  `mouseMoved`  command, and now it can successfully bypass bot detection (at least in my scenario, haha).