### PR TITLE
fix: #1372

### DIFF
--- a/src/workflowEngine/templating/mustacheReplacer.js
+++ b/src/workflowEngine/templating/mustacheReplacer.js
@@ -17,7 +17,7 @@ export function extractStrFunction(str) {
   if (!extractedStr) return null;
   const { 1: name, 2: funcParams } = extractedStr;
   const params = funcParams
-    .split(/,(?=(?:[^'"]*['"][^'"]*['"])*[^'"]*$)/)
+    .split(/,(?=(?:[^'"\\"\\']*['"][^'"]*['"\\"\\'])*[^'"]*$)/)
     .map((param) => param.trim().replace(/^['"]|['"]$/g, '') || '');
 
   return {


### PR DESCRIPTION
With the updated regular expression to support  `\"|\'` , it should be able to handle scenarios where both single and double quotes are present. However, it's true that using only a regular expression might not cover all possible edge cases.

Test cases:

1.  `s = "'',''" // ["''", "''"]`
2.  `s = "',',''" // ["','", "''"]`
3.  `s = "'\',',''" // ["'','", "''"]`