### PR TITLE
Feat: merge all data from all workflows

### DIFF
--- a/src/workflowEngine/WorkflowEngine.js
+++ b/src/workflowEngine/WorkflowEngine.js
@@ -480,6 +480,12 @@ class WorkflowEngine {
       const { table, variables } = this.referenceData;
       const tableId = this.workflow.connectedTable;
 
+      // Merge all table and variables from all workflows
+      Object.values(this.referenceData.workflow).forEach((data) => {
+        Object.assign(table, data.table);
+        Object.assign(variables, data.variables);
+      });
+
       await dbStorage.transaction(
         'rw',
         dbStorage.tablesItems,

--- a/src/workflowEngine/blocksHandler/handlerExecuteWorkflow.js
+++ b/src/workflowEngine/blocksHandler/handlerExecuteWorkflow.js
@@ -2,6 +2,7 @@ import browser from 'webextension-polyfill';
 import { isWhitespace, parseJSON } from '@/utils/helper';
 import decryptFlow, { getWorkflowPass } from '@/utils/decryptFlow';
 import convertWorkflowData from '@/utils/convertWorkflowData';
+import { nanoid } from 'nanoid';
 import WorkflowEngine from '../WorkflowEngine';
 
 function workflowListener(workflow, options) {
@@ -115,14 +116,14 @@ async function executeWorkflow({ id: blockId, data }, { refData }) {
         this.childWorkflowId = engine.id;
       },
       onDestroyed: (engine) => {
-        if (data.executeId) {
-          const { variables, table } = engine.referenceData;
+        const { variables, table } = engine.referenceData;
 
-          this.engine.referenceData.workflow[data.executeId] = {
-            table,
-            variables,
-          };
-        }
+        this.engine.referenceData.workflow[
+          data.executeId || `${engine.id}-${nanoid(8)}`
+        ] = {
+          table,
+          variables,
+        };
       },
     },
     states: this.engine.states,


### PR DESCRIPTION
The parent `WorkflowEngine` will override the storage data modified by the child `WorkflowEngine` ($$variable/table).

> I use a random referenceData.workflow.id for data transmission, which may not be the optimal solution.
