### PR TITLE
Fix: #1532 deleting selected blocks in inactive tab

### DIFF
--- a/src/newtab/pages/workflows/[id].vue
+++ b/src/newtab/pages/workflows/[id].vue
@@ -1528,6 +1528,12 @@ function checkWorkflowUpdate() {
 }
 /* eslint-disable consistent-return */
 function onBeforeLeave() {
+  // disselect node before leave
+  const selectedNodes = editor.value.getSelectedNodes.value;
+  selectedNodes?.forEach((node) => {
+    node.selected = false;
+  });
+
   updateHostedWorkflow();
 
   const dataNotChanged = !state.dataChanged || !haveEditAccess.value;


### PR DESCRIPTION
Fix bug #1532 by deselect all selected nodes before leave.