### PR TITLE
Fix: error when delete workflow

### DIFF
--- a/src/stores/workflow.js
+++ b/src/stores/workflow.js
@@ -282,8 +282,9 @@ export const useWorkflowStore = defineStore('workflow', {
       const { pinnedWorkflows } = await browser.storage.local.get(
         'pinnedWorkflows'
       );
-      const pinnedWorkflowIndex =
-        pinnedWorkflows && pinnedWorkflows.indexOf(id);
+      const pinnedWorkflowIndex = pinnedWorkflows
+        ? pinnedWorkflows.indexOf(id)
+        : -1;
       if (pinnedWorkflowIndex !== -1) {
         pinnedWorkflows.splice(pinnedWorkflowIndex, 1);
         await browser.storage.local.set({ pinnedWorkflows });


### PR DESCRIPTION
pinnedWorkflowIndex will be 'undefined' if 'pin' never use
![image](https://github.com/AutomaApp/automa/assets/32266792/74a96eb2-2de9-42c6-b079-121a77962e60)
