### PR TITLE
Fix bugs with deleting hosted workflows and opening workflows

### DIFF
--- a/src/newtab/pages/Workflows.vue
+++ b/src/newtab/pages/Workflows.vue
@@ -169,7 +169,31 @@ onMounted(() => {
     state.activeTab = activeTab || tabs[0].id;
   }
 
-  if (state.tabs.length !== 0) return;
+  if (state.tabs.length !== 0) {
+    if (/\/workflows\/.+/.test(route.path)) {
+      const routeTab = state.tabs.find((tab) => tab.path === route.path);
+      if (routeTab) {
+        if (routeTab.id !== state.activeTab) {
+          state.activeTab = routeTab.id;
+        }
+      } else {
+        const index = state.tabs.findIndex((tab) => tab.id === state.activeTab);
+        if (index !== -1) {
+          Object.assign(state.tabs[index], {
+            path: route.path,
+            name: getTabTitle(),
+          });
+
+          setTimeout(() => {
+            Object.assign(state.tabs[index], {
+              name: getTabTitle(),
+            });
+          }, 1000);
+        }
+      }
+    }
+    return;
+  }
 
   addTab({
     path: route.path,

--- a/src/popup/pages/Home.vue
+++ b/src/popup/pages/Home.vue
@@ -352,7 +352,7 @@ function renameWorkflow({ id, name }) {
     },
   });
 }
-function deleteWorkflow({ id, name }) {
+function deleteWorkflow({ id, hostId, name }) {
   dialog.confirm({
     title: t('home.workflow.delete'),
     okVariant: 'danger',
@@ -361,7 +361,7 @@ function deleteWorkflow({ id, name }) {
       if (state.activeTab === 'local') {
         workflowStore.delete(id);
       } else {
-        hostedWorkflowStore.delete(id);
+        hostedWorkflowStore.delete(hostId);
       }
     },
   });
@@ -419,7 +419,7 @@ onMounted(async () => {
   await automa('app');
 
   if (activeTab === 'team' && !userStore.user?.teams) activeTab = 'local';
-  else if (activeTab === 'host' && hostedWorkflowStore.toArray.length < 0)
+  else if (activeTab === 'host' && hostedWorkflowStore.toArray.length < 1)
     activeTab = 'local';
 
   state.retrieved = true;


### PR DESCRIPTION
1.The wrong id was used when deleting hosted workflows from the popup page.
2.When opening the workflow detail page from other pages like the popup or logs page, the current route path was being replaced by the activeTab stored in localStorage. I changed it to prioritize using the current route path when it is a child route. You may need to evaluate if this change has any unintended side effects. Here is a gif demonstrating the bug:
![GIF](https://github.com/AutomaApp/automa/assets/32266792/b76513c9-9d99-48d4-80e3-a24784d732db)
