### PR TITLE
feat: improve blocks configuration UI interaction

### DIFF
--- a/src/components/newtab/workflow/edit/EditInteractionBase.vue
+++ b/src/components/newtab/workflow/edit/EditInteractionBase.vue
@@ -29,11 +29,11 @@
         />
       </div>
       <edit-autocomplete v-if="!hideSelector" class="mb-1">
-        <ui-input
+        <ui-textarea
           v-if="!hideSelector"
           :model-value="data.selector"
           :placeholder="t('workflow.blocks.base.selector')"
-          autocomplete="off"
+          autoresize
           class="w-full"
           @change="updateData({ selector: $event })"
         />

--- a/src/components/ui/UiExpand.vue
+++ b/src/components/ui/UiExpand.vue
@@ -31,7 +31,7 @@ import { watch, ref } from 'vue';
 const props = defineProps({
   modelValue: {
     type: Boolean,
-    default: false,
+    default: true,
   },
   panelClass: {
     type: String,

--- a/src/components/ui/UiTextarea.vue
+++ b/src/components/ui/UiTextarea.vue
@@ -5,7 +5,6 @@
     ref="textarea"
     :value="modelValue"
     class="ui-textarea ui-input bg-input w-full rounded-lg px-4 py-2 transition"
-    :class="{ 'overflow-hidden resize-none': autoresize }"
     @input="emitValue"
     @keyup="$emit('keyup', $event)"
     @keydown="$emit('keydown', $event)"


### PR DESCRIPTION
- Change Block's CSS/XPath Selector to a resizable `textarea` that automatically adjusts to the content height by default, instead of a narrow one-line `input`.
- **Expand block options by default** to clearly show which options are available or have been modified when switching between each blocks.

Preview screenshot:

![img_v3_02ab_5d905dea-8610-4a29-b548-033ed6039d0g](https://github.com/AutomaApp/automa/assets/15135943/1817a711-bf01-466c-b3f6-5077e91dafe4)
