### PR TITLE
fix: ensure correct active tab detection from the extension dashboard

### DIFF
--- a/src/manifest.chrome.json
+++ b/src/manifest.chrome.json
@@ -55,6 +55,7 @@
   ],
   "permissions": [
     "tabs",
+    "activeTab",
     "proxy",
     "alarms",
     "storage",

--- a/src/utils/helper.js
+++ b/src/utils/helper.js
@@ -2,29 +2,19 @@ import browser from 'webextension-polyfill';
 
 export async function getActiveTab() {
   try {
-    let windowId = null;
     const tabsQuery = {
       active: true,
       url: '*://*/*',
     };
-    const extURL = browser.runtime.getURL('');
-    const windows = await browser.windows.getAll({ populate: true });
-    for (const browserWindow of windows) {
-      const [tab] = browserWindow.tabs;
-      const isDashboard =
-        browserWindow.tabs.length === 1 && tab.url?.includes(extURL);
 
-      if (isDashboard) {
-        await browser.windows.update(browserWindow.id, {
-          focused: false,
-        });
-      } else if (browserWindow.focused) {
-        windowId = browserWindow.id;
-      }
-    }
+    const window = await browser.windows.getLastFocused({
+      populate: true,
+      windowTypes: ['normal'],
+    });
+    const windowId = window.id;
 
     if (windowId) tabsQuery.windowId = windowId;
-    else if (windows.length > 2) tabsQuery.lastFocusedWindow = true;
+    else tabsQuery.lastFocusedWindow = true;
 
     const [tab] = await browser.tabs.query(tabsQuery);
 


### PR DESCRIPTION
fix: ensure correct active tab detection from the extension dashboard

When trying to detect the **"active tab"** from the **Automa extension's dashboard** (like when triggering a CSS selector), the dashboard window is always focused. This caused the original code to fail in correctly identifying the active tab and throw error.

Now, using the [`windows.getLastFocused()`](https://developer.mozilla.org/en-US/docs/Mozilla/Add-ons/WebExtensions/API/windows/getLastFocused) API to query "`normal`" type window, we can accurately fetch the active tab without extension's panel window.

That's fix both of **"Element Selector"** and **"Record Workflow"** / **"Record from here"** functions.

Issue example screenshot:

<img width="1081" alt="image" src="https://github.com/AutomaApp/automa/assets/15135943/031742f9-89d3-4e8d-bf12-15585ef06657">
