### PR TITLE
feat: improve command palette with fuzzy search

### DIFF
--- a/package.json
+++ b/package.json
@@ -63,6 +63,7 @@
     "dayjs": "^1.11.6",
     "defu": "^6.1.2",
     "dexie": "^3.2.3",
+    "fuzzaldrin-plus": "^0.6.0",
     "html2canvas": "^1.4.1",
     "idb": "^7.0.2",
     "js-base64": "^3.7.5",

--- a/src/content/commandPalette/App.vue
+++ b/src/content/commandPalette/App.vue
@@ -185,6 +185,7 @@ import {
 } from 'vue';
 import browser from 'webextension-polyfill';
 import cloneDeep from 'lodash.clonedeep';
+import { filter } from 'fuzzaldrin-plus';
 import workflowParameters from '@business/parameters';
 import { sendMessage } from '@/utils/message';
 import { debounce, parseJSON } from '@/utils/helper';
@@ -226,11 +227,11 @@ const paramsState = reactive({
 
 const rootElement = inject('rootElement');
 
-const workflows = computed(() =>
-  state.workflows.filter((workflow) =>
-    workflow.name.toLocaleLowerCase().includes(state.query.toLocaleLowerCase())
-  )
-);
+const workflows = computed(() => {
+  if (!state.query) return state.workflows;
+
+  return filter(state.workflows, state.query, { key: 'name' });
+});
 
 function getReadableShortcut(str) {
   const list = {

--- a/yarn.lock
+++ b/yarn.lock
@@ -4035,6 +4035,11 @@ functions-have-names@^1.2.3:
   resolved "https://registry.yarnpkg.com/functions-have-names/-/functions-have-names-1.2.3.tgz#0404fe4ee2ba2f607f0e0ec3c80bae994133b834"
   integrity sha512-xckBUXyTIqT97tq2x2AMb+g163b5JFysYk0x4qxNFwbfQkmNZoiRHb6sPzI9/QV33WeuvVYBUIiD4NzNIyqaRQ==
 
+fuzzaldrin-plus@^0.6.0:
+  version "0.6.0"
+  resolved "https://registry.yarnpkg.com/fuzzaldrin-plus/-/fuzzaldrin-plus-0.6.0.tgz#832f6489fbe876769459599c914a670ec22947ee"
+  integrity sha512-srIDThJHkdp3aPwJpR/HNzYZCRJwm07b/igxseoHSB7qR8e/gQp4F6lMGknE3TQI1Aq14TiFf/wzrHOp9LY/EA==
+
 gensync@^1.0.0-beta.2:
   version "1.0.0-beta.2"
   resolved "https://registry.yarnpkg.com/gensync/-/gensync-1.0.0-beta.2.tgz#32a6ee76c3d7f52d46b2b1ae5d93fea8580a25e0"


### PR DESCRIPTION
When typing in workflow names using the command palette, I often find myself wanting Sublime Text like fuzzy matching so I don't have to remember the full, exact name of the workflow.

This PR adds the fuzzaldrin-plus package, (a rewrite of fuzzaldrin used in the Atom editor) and uses it in the command palette to filter workflows.

* https://github.com/jeancroy/fuzz-aldrin-plus
* https://github.com/atom/fuzzaldrin