### PR TITLE
Fix (migrate-mv3): Send message

### DIFF
--- a/src/background/BackgroundWorkflowUtils.js
+++ b/src/background/BackgroundWorkflowUtils.js
@@ -130,10 +130,10 @@ class BackgroundWorkflowUtils {
       return;
     }
 
-    await BackgroundOffscreen.instance.sendMessage(
-      'workflow:execute',
-      workflowData
-    );
+    await BackgroundOffscreen.instance.sendMessage('workflow:execute', {
+      workflowData,
+      options,
+    });
   }
 }
 

--- a/src/manifest.chrome.json
+++ b/src/manifest.chrome.json
@@ -65,7 +65,8 @@
     "activeTab",
     "offscreen",
     "webNavigation",
-    "unlimitedStorage"
+    "unlimitedStorage",
+    "scripting"
   ],
   "web_accessible_resources": [
     {

--- a/src/newtab/pages/workflows/[id].vue
+++ b/src/newtab/pages/workflows/[id].vue
@@ -704,6 +704,8 @@ async function executeFromBlock(blockId) {
     if (tab) {
       workflowOptions.tabId = tab.id;
     }
+    await browser.tabs.update(tab.id, { active: true });
+    await browser.windows.update(tab.windowId, { focused: true });
 
     RendererWorkflowService.executeWorkflow(workflow.value, workflowOptions);
   } catch (error) {

--- a/src/offscreen/message-listener.js
+++ b/src/offscreen/message-listener.js
@@ -7,7 +7,7 @@ const messageListener = new MessageListener('offscreen');
 Browser.runtime.onMessage.addListener(messageListener.listener);
 
 messageListener.on('workflow:execute', (data) => {
-  WorkflowManager.instance.execute(data);
+  WorkflowManager.instance.execute(data.workflowData, data.options);
 });
 
 messageListener.on('workflow:stop', (stateId) => {

--- a/src/service/browser-api/browser-api-map.js
+++ b/src/service/browser-api/browser-api-map.js
@@ -14,6 +14,7 @@ export const browserAPIMap = [
   { api: () => Browser.tabs.goForward, path: 'tabs.goForward' },
   { api: () => Browser.tabs.captureTab, path: 'tabs.captureTab' },
   { api: () => Browser.tabs.captureVisibleTab, path: 'tabs.captureVisibleTab' },
+  { api: () => Browser.tabs.sendMessage, path: 'tabs.sendMessage' },
   { isEvent: true, api: () => Browser.tabs.onRemoved, path: 'tabs.onRemoved' },
   {
     isEvent: true,

--- a/src/workflowEngine/helper.js
+++ b/src/workflowEngine/helper.js
@@ -107,27 +107,28 @@ export function waitTabLoaded({ tabId, listenError = false, ms = 10000 }) {
         onErrorOccurred
       );
 
-    const activeTabStatus = () => {
-      BrowserAPIService.tabs.get(tabId).then((tab) => {
-        if (!tab) {
-          reject(new Error('no-tab'));
-          return;
-        }
+    const activeTabStatus = async () => {
+      const tab = await BrowserAPIService.tabs.get(tabId);
+      // then((tab) => {
+      if (!tab) {
+        reject(new Error('no-tab'));
+        return;
+      }
 
-        if (tab.status === 'loading') {
-          setTimeout(() => {
-            activeTabStatus();
-          }, 1000);
-          return;
-        }
+      if (tab.status === 'loading') {
+        setTimeout(() => {
+          activeTabStatus();
+        }, 1000);
+        return;
+      }
 
-        clearTimeout(timeout);
+      clearTimeout(timeout);
 
-        BrowserAPIService.webNavigation.onErrorOccurred.removeListener(
-          onErrorOccurred
-        );
-        resolve();
-      });
+      BrowserAPIService.webNavigation.onErrorOccurred.removeListener(
+        onErrorOccurred
+      );
+      resolve();
+      // });
     };
 
     activeTabStatus();

--- a/src/workflowEngine/helper.js
+++ b/src/workflowEngine/helper.js
@@ -109,7 +109,6 @@ export function waitTabLoaded({ tabId, listenError = false, ms = 10000 }) {
 
     const activeTabStatus = async () => {
       const tab = await BrowserAPIService.tabs.get(tabId);
-      // then((tab) => {
       if (!tab) {
         reject(new Error('no-tab'));
         return;
@@ -128,7 +127,6 @@ export function waitTabLoaded({ tabId, listenError = false, ms = 10000 }) {
         onErrorOccurred
       );
       resolve();
-      // });
     };
 
     activeTabStatus();


### PR DESCRIPTION
Changelog :

- I add sendMessage into the browser API wrapper to fix the Send Message error. 
- Add scripting permission for adding element selector script injection. 
- Switch to the execution tab after the block is executed.
- Tested on Windows and Chrome systems.

Let me know if any other things should be added.