### PR TITLE
fix(ui/autocomplete): prevent keydown handling when popover is hidden

### DIFF
--- a/src/components/ui/UiAutocomplete.vue
+++ b/src/components/ui/UiAutocomplete.vue
@@ -266,6 +266,10 @@ function selectItem(itemIndex, selected) {
   }
 }
 function handleKeydown(event) {
+  if (!state.showPopover) {
+    return;
+  }
+
   const itemsLength = filteredItems.value.length - 1;
 
   if (event.key === 'ArrowUp') {


### PR DESCRIPTION
fix the the issue (The bug prevents users from navigating the cursor within a multiline text input field using keyboard arrow keys) 

[!1927](https://github.com/AutomaApp/automa/issues/1927)