### PR TITLE
fix: Correct URL parameter parsing in execute page

### DIFF
--- a/src/execute/index.js
+++ b/src/execute/index.js
@@ -11,7 +11,7 @@ function getWorkflowDetail() {
   const variables = {};
   const { 1: workflowId } = pathname.split('/');
 
-  searchParams.forEach((key, value) => {
+  searchParams.forEach((value, key) => {
     const varValue = parseJSON(decodeURIComponent(value), '##_empty');
     if (varValue === '##_empty') return;
 


### PR DESCRIPTION
Fix: https://github.com/AutomaApp/automa/issues/1742

The `forEach` callback for `URLSearchParams` in `src/execute/index.js` had its `key` and `value` parameters inadvertently swapped. 

This resulted in incorrect parsing of URL query parameters, where the intended value was treated as the key and vice-versa.

This commit corrects the parameter order to `(value, key)`, restoring the standard `key=value` parsing behavior for URL parameters passed to the execute page.

