### PR TITLE
chore: new docs url

### DIFF
--- a/README.md
+++ b/README.md
@@ -36,7 +36,7 @@ Auto-fill forms, do a repetitive task, take a screenshot, or scrape website data
 Browse the Automa marketplace where you can share and download workflows with others. [Go to the marketplace &#187;](https://www.automa.site/marketplace)
 
 ## Automa Chrome Extension Builder
-Automa Chrome Extension Builder (Automa CEB for short) allows you to generate a standalone chrome extension based on Automa workflows. [Go to the documentation &#187;](https://docs.automa.site/extension-builder)
+Automa Chrome Extension Builder (Automa CEB for short) allows you to generate a standalone chrome extension based on Automa workflows. [Go to the documentation &#187;](https://docs.extension.automa.site/extension-builder)
 
 
 ## Project setup

--- a/src/components/newtab/logs/LogsHistory.vue
+++ b/src/components/newtab/logs/LogsHistory.vue
@@ -17,7 +17,7 @@
               {{ errorBlock.message }}
               <a
                 v-if="errorBlock.messageId"
-                :href="`https://docs.automa.site/reference/workflow-common-errors.html#${errorBlock.messageId}`"
+                :href="`https://docs.extension.automa.site/reference/workflow-common-errors.html#${errorBlock.messageId}`"
                 target="_blank"
                 title="About the error"
                 @click.stop
@@ -134,7 +134,7 @@
                 {{ item.message }}
                 <a
                   v-if="item.messageId"
-                  :href="`https://docs.automa.site/reference/workflow-common-errors.html#${item.messageId}`"
+                  :href="`https://docs.extension.automa.site/reference/workflow-common-errors.html#${item.messageId}`"
                   target="_blank"
                   title="About the error"
                   @click.stop

--- a/src/components/newtab/workflow/WorkflowBlockList.vue
+++ b/src/components/newtab/workflow/WorkflowBlockList.vue
@@ -23,7 +23,7 @@
           class="invisible absolute right-2 top-2 flex items-center text-gray-600 group-hover:visible dark:text-gray-300"
         >
           <a
-            :href="`https://docs.automa.site/blocks/${block.id}.html`"
+            :href="`https://docs.extension.automa.site/blocks/${block.id}.html`"
             :title="t('common.docs')"
             target="_blank"
             rel="noopener"

--- a/src/components/newtab/workflow/WorkflowEditBlock.vue
+++ b/src/components/newtab/workflow/WorkflowEditBlock.vue
@@ -12,7 +12,7 @@
       <div class="grow"></div>
       <a
         :title="t('common.docs')"
-        :href="`https://docs.automa.site/blocks/${data.id}.html`"
+        :href="`https://docs.extension.automa.site/blocks/${data.id}.html`"
         rel="noopener"
         target="_blank"
         class="text-gray-600 dark:text-gray-200"

--- a/src/components/newtab/workflow/edit/EditCreateElement.vue
+++ b/src/components/newtab/workflow/edit/EditCreateElement.vue
@@ -71,7 +71,7 @@
               <a
                 v-for="func in availableFuncs"
                 :key="func.id"
-                :href="`https://docs.automa.site/blocks/javascript-code.html#${func.id}`"
+                :href="`https://docs.extension.automa.site/blocks/javascript-code.html#${func.id}`"
                 target="_blank"
                 rel="noopener"
                 class="bg-box-transparent inline-block rounded-md p-1 text-sm"

--- a/src/components/newtab/workflow/edit/EditGoogleDrive.vue
+++ b/src/components/newtab/workflow/edit/EditGoogleDrive.vue
@@ -4,7 +4,7 @@
       <p>
         You haven't
         <a
-          href="https://docs.automa.site/integrations/google-drive.html"
+          href="https://docs.extension.automa.site/integrations/google-drive.html"
           target="_blank"
           class="underline"
           >connected Automa to Google Drive</a

--- a/src/components/newtab/workflow/edit/EditGoogleSheets.vue
+++ b/src/components/newtab/workflow/edit/EditGoogleSheets.vue
@@ -31,7 +31,7 @@
         <template #label>
           {{ t('workflow.blocks.google-sheets.spreadsheetId.label') }}*
           <a
-            href="https://docs.automa.site/blocks/google-sheets.html#spreadsheet-id"
+            href="https://docs.extension.automa.site/blocks/google-sheets.html#spreadsheet-id"
             target="_blank"
             rel="noopener"
             :title="t('workflow.blocks.google-sheets.spreadsheetId.link')"
@@ -43,7 +43,7 @@
     </edit-autocomplete>
     <a
       v-if="!state.havePermission"
-      href="https://docs.automa.site/blocks/google-sheets.html#access-to-spreadsheet"
+      href="https://docs.extension.automa.site/blocks/google-sheets.html#access-to-spreadsheet"
       target="_blank"
       rel="noopener"
       class="ml-1 inline-block text-sm leading-tight"
@@ -61,7 +61,7 @@
         <template #label>
           {{ t('workflow.blocks.google-sheets.range.label') }}*
           <a
-            href="https://docs.automa.site/blocks/google-sheets.html#range"
+            href="https://docs.extension.automa.site/blocks/google-sheets.html#range"
             target="_blank"
             rel="noopener"
             :title="t('workflow.blocks.google-sheets.range.link')"

--- a/src/components/newtab/workflow/edit/EditGoogleSheetsDrive.vue
+++ b/src/components/newtab/workflow/edit/EditGoogleSheetsDrive.vue
@@ -3,7 +3,7 @@
     <p>
       You haven't
       <a
-        href="https://docs.automa.site/integrations/google-drive.html"
+        href="https://docs.extension.automa.site/integrations/google-drive.html"
         target="_blank"
         class="underline"
         >connected Automa to Google Drive</a

--- a/src/components/newtab/workflow/edit/EditInsertData.vue
+++ b/src/components/newtab/workflow/edit/EditInsertData.vue
@@ -239,7 +239,7 @@ function changeItemType(index, type) {
 }
 function setAsFile(item) {
   if (!hasFileAccess.value) {
-    window.open('https://docs.automa.site/blocks/insert-data.html#import-file');
+    window.open('https://docs.extension.automa.site/blocks/insert-data.html#import-file');
     return;
   }
 

--- a/src/components/newtab/workflow/edit/EditJavascriptCode.vue
+++ b/src/components/newtab/workflow/edit/EditJavascriptCode.vue
@@ -103,7 +103,7 @@
               <a
                 v-for="func in availableFuncs"
                 :key="func.id"
-                :href="`https://docs.automa.site/blocks/javascript-code.html#${func.id}`"
+                :href="`https://docs.extension.automa.site/blocks/javascript-code.html#${func.id}`"
                 target="_blank"
                 rel="noopener"
                 class="inline-block"

--- a/src/components/newtab/workflow/edit/EditUploadFile.vue
+++ b/src/components/newtab/workflow/edit/EditUploadFile.vue
@@ -49,7 +49,7 @@
         </div>
       </div>
       <a
-        href="https://docs.automa.site/blocks/upload-file.html#requirements"
+        href="https://docs.extension.automa.site/blocks/upload-file.html#requirements"
         target="_blank"
         rel="noopener"
         class="mt-2 inline-block leading-tight text-primary"

--- a/src/components/newtab/workflow/edit/EditWebhook.vue
+++ b/src/components/newtab/workflow/edit/EditWebhook.vue
@@ -141,7 +141,7 @@
       />
       <div class="mt-3">
         <a
-          href="https://docs.automa.site/workflow/expressions.html"
+          href="https://docs.extension.automa.site/workflow/expressions.html"
           rel="noopener"
           class="border-b text-primary"
           target="_blank"

--- a/src/components/newtab/workflow/editor/EditorLocalActions.vue
+++ b/src/components/newtab/workflow/editor/EditorLocalActions.vue
@@ -30,7 +30,7 @@
           </p>
           <a
             :title="t('common.docs')"
-            href="https://docs.automa.site/workflow/sharing-workflow.html#host-workflow"
+            href="https://docs.extension.automa.site/workflow/sharing-workflow.html#host-workflow"
             target="_blank"
             class="ml-1"
           >

--- a/src/components/newtab/workflow/settings/SettingsGeneral.vue
+++ b/src/components/newtab/workflow/settings/SettingsGeneral.vue
@@ -41,7 +41,7 @@
       </p>
     </div>
     <a
-      href="https://docs.automa.site/workflow/settings.html#workflow-execution"
+      href="https://docs.extension.automa.site/workflow/settings.html#workflow-execution"
       class="mr-2"
       target="_blank"
     >
@@ -132,7 +132,7 @@
       </p>
     </div>
     <a
-      href="https://docs.automa.site/blocks/trigger.html#trigger-using-js-customevent"
+      href="https://docs.extension.automa.site/blocks/trigger.html#trigger-using-js-customevent"
       target="_blank"
       rel="noopener"
       class="mr-2 text-gray-600 dark:text-gray-200"

--- a/src/newtab/App.vue
+++ b/src/newtab/App.vue
@@ -53,7 +53,7 @@
         <p>
           Export your Automa workflows as a standalone extension using
           <a
-            href="https://docs.automa.site/extension-builder/"
+            href="https://docs.extension.automa.site/extension-builder/"
             target="_blank"
             class="underline"
             >Automa Chrome Extension Builder</a

--- a/src/newtab/pages/Storage.vue
+++ b/src/newtab/pages/Storage.vue
@@ -5,7 +5,7 @@
         {{ t('common.storage') }}
       </h1>
       <a
-        href="https://docs.automa.site/reference/storage.html"
+        href="https://docs.extension.automa.site/reference/storage.html"
         title="Docs"
         class="ml-2 text-gray-600 dark:text-gray-200"
         target="_blank"

--- a/src/newtab/pages/workflows/[id].vue
+++ b/src/newtab/pages/workflows/[id].vue
@@ -463,7 +463,7 @@ const workflowModals = {
     width: 'max-w-2xl',
     component: WorkflowDataTable,
     title: t('workflow.table.title'),
-    docs: 'https://docs.automa.site/workflow/table.html',
+    docs: 'https://docs.extension.automa.site/workflow/table.html',
     events: {
       /* eslint-disable-next-line */
       connect: fetchConnectedTable,
@@ -515,7 +515,7 @@ const workflowModals = {
     icon: 'riDatabase2Line',
     component: WorkflowGlobalData,
     title: t('common.globalData'),
-    docs: 'https://docs.automa.site/workflow/global-data.html',
+    docs: 'https://docs.extension.automa.site/workflow/global-data.html',
   },
   settings: {
     width: 'max-w-2xl',

--- a/src/newtab/pages/workflows/index.vue
+++ b/src/newtab/pages/workflows/index.vue
@@ -309,7 +309,7 @@
           <p class="mt-4">
             Learn more about recording in
             <a
-              href="https://docs.automa.site/guide/quick-start.html#recording-actions"
+              href="https://docs.extension.automa.site/guide/quick-start.html#recording-actions"
               target="_blank"
               >the documentation</a
             >

--- a/src/popup/pages/Home.vue
+++ b/src/popup/pages/Home.vue
@@ -164,7 +164,7 @@
         If the workflow runs for less than 5 minutes, set it to run in the
         background in the
         <a
-          href="https://docs.automa.site/workflow/settings.html#workflow-execution"
+          href="https://docs.extension.automa.site/workflow/settings.html#workflow-execution"
           class="font-semibold underline"
           target="_blank"
         >
@@ -289,7 +289,7 @@ const showTab = computed(
 
 function openDocs() {
   window.open(
-    'https://docs.automa.site/guide/quick-start.html#recording-actions',
+    'https://docs.extension.automa.site/guide/quick-start.html#recording-actions',
     '_blank'
   );
 }

--- a/src/utils/codeEditorAutocomplete.js
+++ b/src/utils/codeEditorAutocomplete.js
@@ -86,7 +86,7 @@ export const automaFuncsSnippets = {
         <code>automaNextBlock(<i>data</i>, <i>insert?</i>)</code>
         <p class="mt-2">
           Execute the next block
-          <a href="https://docs.automa.site/blocks/javascript-code.html#automanextblock-data" target="_blank" class="underline">
+          <a href="https://docs.extension.automa.site/blocks/javascript-code.html#automanextblock-data" target="_blank" class="underline">
             Read more
           </a>
         </p>
@@ -137,7 +137,7 @@ export const automaFuncsSnippets = {
         <code>automaRefData(<i>keyword</i>, <i>path</i>)</code>
         <p class="mt-2">
           Use this function to
-          <a href="https://docs.automa.site/workflow/expressions.html" target="_blank" class="underline">
+          <a href="https://docs.extension.automa.site/workflow/expressions.html" target="_blank" class="underline">
             reference data
           </a>
         </p>


### PR DESCRIPTION
I noticed that the doc for the Automa extension has changed to a new address, but the URL in the extension has not changed synchronously.

This PR replaces all old URLs with the new one.