### PR TITLE
fix recording multiple times on the same page,  need to listen to the corresponding runtime.onMessage

### DIFF
--- a/src/content/services/recordWorkflow/index.js
+++ b/src/content/services/recordWorkflow/index.js
@@ -11,9 +11,9 @@ import selectorFrameContext from '../../elementSelector/selectorFrameContext';
 
     if (isMainFrame) {
       const element = document.querySelector('#automa-recording');
-      if (element) return;
-
-      elementSelectorInstance = await initElementSelector();
+      if (!element) {
+        elementSelectorInstance = await initElementSelector();
+      }
     } else {
       const style = document.createElement('style');
       style.textContent = '[automa-el-list] {outline: 2px dashed #6366f1;}';


### PR DESCRIPTION
When recording is stopped for the first time, mainFrame receives the recording:stop message, and destroyRecordEvents clears the operation event listener bound to the document. At this time, when recording is started for the second time on the current page, the document will be monitored again. However, due to the existence of the #automa-recording element, runtime.onMessage will not listen. As a result, when recording is stopped for the second time, the recording:stop message cannot be received as expected, and the destroyRecordEvents operation cannot be performed, resulting in the document not destroying the listener. At this time, when recording is started for the third time, click and other operations will cause repeated listening.