### PR TITLE
fix: IIllegal invocation when use proxy block: Function must be calle…

### DIFF
--- a/src/service/browser-api/browser-api-map.js
+++ b/src/service/browser-api/browser-api-map.js
@@ -49,8 +49,14 @@ export const browserAPIMap = [
   { api: () => Browser.storage.local.get, path: 'storage.local.get' },
   { api: () => Browser.storage.local.set, path: 'storage.local.set' },
   { api: () => Browser.storage.local.remove, path: 'storage.local.remove' },
-  { api: () => Browser.proxy.settings.clear, path: 'proxy.settings.clear' },
-  { api: () => Browser.proxy.settings.set, path: 'proxy.settings.set' },
+  {
+    api: () => Browser.proxy.settings.clear.bind(Browser.proxy.settings),
+    path: 'proxy.settings.clear',
+  },
+  {
+    api: () => Browser.proxy.settings.set.bind(Browser.proxy.settings),
+    path: 'proxy.settings.set',
+  },
   {
     isEvent: true,
     path: 'debugger.onEvent',

--- a/src/workflowEngine/WorkflowEngine.js
+++ b/src/workflowEngine/WorkflowEngine.js
@@ -452,7 +452,7 @@ class WorkflowEngine {
 
     try {
       if (this.isDestroyed) return;
-      if (this.isUsingProxy) BrowserAPIService.proxy.clearSettings({});
+      if (this.isUsingProxy) BrowserAPIService.proxy.settings.clear({});
       if (this.workflow.settings.debugMode && BROWSER_TYPE === 'chrome') {
         BrowserAPIService.debugger.onEvent.removeListener(this.onDebugEvent);
 


### PR DESCRIPTION
<img width="899" height="92" alt="image" src="https://github.com/user-attachments/assets/b38e9350-bd9d-4eaf-941e-517e1b3571f2" />
When call through BrowserAPIService. proxy. settings. set, its this becomes BrowserAPIService. proxy. settings (a common object), not the original ChromeSetting instance